### PR TITLE
Fixes for SDMX 2.1 Structure Tests

### DIFF
--- a/sdmx-tck-manager/src/checker/HttpResponseValidator.js
+++ b/sdmx-tck-manager/src/checker/HttpResponseValidator.js
@@ -24,7 +24,7 @@ class HttpResponseValidator {
             } catch (err) {
                 let tckStatus = FAILURE_CODE;
                 let code = httpResponse != null ? httpResponse.status : void 0;
-                if (code === 404 || code === 501) {
+                if (code === 404 || code === 501 || code === 406) {
                     tckStatus = SUCCESS_CODE;
                 }
                 resolve({ status: tckStatus, url: httpResponse.url, httpStatus: httpResponse.status, error: err.toString() });
@@ -72,7 +72,7 @@ class HttpResponseValidator {
         if (!isDefined(response) && !response.status) {
             throw new TckError('No response status')
         }
-        if (response.status !== "406") {
+        if (response.status !== 406) {
             throw new TckError("Response status was not 406 but " + response.status + " instead");
         }
     }

--- a/sdmx-tck-manager/src/manager/StructureTestExecutionManager.js
+++ b/sdmx-tck-manager/src/manager/StructureTestExecutionManager.js
@@ -61,10 +61,10 @@ class StructureTestExecutionManager {
             console.log("Test: " + toRun.testId + " SDMX workspace created.");
         
             // If the Rest Resource is "structure" then we have to call the getRandomSdmxObject() function.
-            var randomStructure = workspace.getRandomSdmxObjectOfType(SDMX_STRUCTURE_TYPE.fromRestResource(toRun.resource));
-            if (toRun.resource === "structure") {
-                randomStructure = workspace.getRandomSdmxObject();
-            }
+            let randomStructure = (toRun.resource === "structure")
+                ? workspace.getRandomSdmxObject()
+                : workspace.getRandomSdmxObjectOfType(SDMX_STRUCTURE_TYPE.fromRestResource(toRun.resource));
+
             testResult.randomStructure = {
                 structureType: randomStructure.getStructureType(),
                 agencyId: randomStructure.getAgencyId(),

--- a/sdmx-tck-parsers/src/parsers/structure-queries-parsers/SdmxV21StructuresParser.js
+++ b/sdmx-tck-parsers/src/parsers/structure-queries-parsers/SdmxV21StructuresParser.js
@@ -232,9 +232,10 @@ class SdmxV21StructuresParser {
                     structures.set(structureType, []);
                 }
                 structures.get(structureType).push(
-                    new MaintainableObject(structureType, hierarchicalCodelist,
+                    new ItemSchemeObject(structureType, hierarchicalCodelist,
                         SdmxV21StructureReferencesParser.getReferences(hierarchicalCodelist),
-                        SdmxV21JsonForStubsParser.getDetail(structureType, hierarchicalCodelist)
+                        SdmxV21JsonForStubsParser.getDetail(structureType, hierarchicalCodelist),
+                        SdmxV21JsonItemsParser.getItems(structureType, hierarchicalCodelist)
                     )
                 );
             }


### PR DESCRIPTION
### Fixes handling of 406 response code
During the execution of the `/codelist/agency/id/version (invalid representation query)` test, 406 status is expected as per the spec. Yet, existing code was not handling this status properly which resulted in test execution error, despite the server under test responding with expected status.

### Fixes hierarchical codelist's base type
Although `HierarchicalCodelist` (HC for short) is not extending `ItemScheme` base type in the information model, it is still assumed by the [REST spec](https://github.com/sdmx-twg/sdmx-rest/blob/v1.5.0/v2_1/ws/rest/docs/4_3_structural_queries.mdx) that it will be a subject to item scheme queries. So, the test infrastructure attempts so select a random set of `Hierarchy` items from HC and code fails to do so, because object which is used to enclose HC information is a `MaintainableObject` type. At the same time HC is listed as a member in the `ITEM_SCHEME_TYPES` enumeration. So in order for the test code to be able to select random items of the HC, its info carrier object was changed to `ItemSchemeObject`

### Fixes handling of 'structure' request type parameter
When `/structure/all/all/all` test is executed, the code attempted to select a random object from the workspace by the `structure` type. Call to `SDMX_STRUCTURE_TYPE.fromRestResource(toRun.resource)` resulted in `null` which in turn triggered the error by the `workspace.getRandomSdmxObjectOfType()` function invocation with `'Missing mandatory parameter \'structureType\''` message. Because of this, child tests would also fail. 
Restructured the test code to execute only one of two possible condition branches (random by type VS any random from workspace).